### PR TITLE
add snake self-collision test

### DIFF
--- a/Source/SnakeGame/Tests/Game.spec.cpp
+++ b/Source/SnakeGame/Tests/Game.spec.cpp
@@ -75,25 +75,6 @@ void FSnakeGame::Define()
                 CoreGame->update(1.0f, Input::Default);
                 TestTrueExpr(bGameOver);
             });
-        It("SnakeShouldMoveCorrectlyNextToItsTail",
-            [this]()
-            {
-                bool bGameOver{false};
-                CoreGame->subscribeOnGameplayEvent(
-                    [&](GameplayEvent Event)
-                    {
-                        if (Event == GameplayEvent::GameOver)
-                        {
-                            bGameOver = true;
-                        }
-                    });
-
-                CoreGame->update(GS.gameSpeed, {0, 1});   // move down
-                CoreGame->update(GS.gameSpeed, {-1, 0});  // move left
-                CoreGame->update(GS.gameSpeed, {0, -1});  // move up
-
-                TestTrueExpr(!bGameOver);  // the snake shouldn't bite its tail
-            });
     });
 
     Describe("Core.Game", [this]() {  //
@@ -133,7 +114,37 @@ void FSnakeGame::Define()
                 TestTrueExpr(CoreGame->score() == 2);
                 TestTrueExpr(Score == 2);
             });
+    });
 
+    Describe("Core.Game", [this]() {  //
+        It("SnakeShouldMoveCorrectlyNextToItsTail",
+            [this]()
+            {
+                auto Randomizer = MakeShared<MockPositionRandomizer>();
+                Randomizer->setPositions({Position{1, 1}, Position{1, 1}, Position{1, 1}, Position{1, 1}});
+
+                GS.gridDims = Dim{10, 10};
+                GS.snake.defaultSize = 4;
+                GS.snake.startPosition = Grid::center(GS.gridDims.width, GS.gridDims.height);
+                GS.gameSpeed = 1.0f;
+                CoreGame = MakeUnique<Game>(GS, Randomizer);
+
+                bool bGameOver{false};
+                CoreGame->subscribeOnGameplayEvent(
+                    [&](GameplayEvent Event)
+                    {
+                        if (Event == GameplayEvent::GameOver)
+                        {
+                            bGameOver = true;
+                        }
+                    });
+
+                CoreGame->update(GS.gameSpeed, {0, 1});   // move down
+                CoreGame->update(GS.gameSpeed, {-1, 0});  // move left
+                CoreGame->update(GS.gameSpeed, {0, -1});  // move up
+
+                TestTrueExpr(!bGameOver);  // the snake shouldn't bite its tail
+            });
     });
 }
 

--- a/Source/SnakeGame/Tests/Game.spec.cpp
+++ b/Source/SnakeGame/Tests/Game.spec.cpp
@@ -43,6 +43,7 @@ void FSnakeGame::Define()
             [this]()
             {
                 GS.gridDims = Dim{10, 10};
+                GS.snake.defaultSize = 4;
                 GS.snake.startPosition = Grid::center(GS.gridDims.width, GS.gridDims.height);
                 GS.gameSpeed = 1.0f;
                 CoreGame = MakeUnique<Game>(GS);
@@ -74,7 +75,25 @@ void FSnakeGame::Define()
                 CoreGame->update(1.0f, Input::Default);
                 TestTrueExpr(bGameOver);
             });
+        It("SnakeShouldMoveCorrectlyNextToItsTail",
+            [this]()
+            {
+                bool bGameOver{false};
+                CoreGame->subscribeOnGameplayEvent(
+                    [&](GameplayEvent Event)
+                    {
+                        if (Event == GameplayEvent::GameOver)
+                        {
+                            bGameOver = true;
+                        }
+                    });
 
+                CoreGame->update(GS.gameSpeed, {0, 1});   // move down
+                CoreGame->update(GS.gameSpeed, {-1, 0});  // move left
+                CoreGame->update(GS.gameSpeed, {0, -1});  // move up
+
+                TestTrueExpr(!bGameOver);  // the snake shouldn't bite its tail
+            });
     });
 
     Describe("Core.Game", [this]() {  //


### PR DESCRIPTION
После внесения изменений в уроке 4, связанных с учетом положения головы на модельной сетке, хвост змеи стал как-бы запаздывать на одно звено. Таким образом змея может "врезаться" в собственный хвост, хотя при движении там должна образовываться пустая ячейка. Данный тест подтверждает наличие этой проблемы.