### PR TITLE
Fix map names

### DIFF
--- a/Source/SnakeGame/Tests/Framework.spec.cpp
+++ b/Source/SnakeGame/Tests/Framework.spec.cpp
@@ -49,7 +49,7 @@ void FSnakeFramework::Define()
             BeforeEach(
                 [this]()
                 {
-                    AutomationOpenMap("GameLevel");
+                    AutomationOpenMap("/Game/Levels/GameLevel");
                     World = GetTestGameWorld();
                 });
             It("ClassesMightBeSetupCorrectly",

--- a/Source/SnakeGame/Tests/World.spec.cpp
+++ b/Source/SnakeGame/Tests/World.spec.cpp
@@ -34,7 +34,7 @@ void FSnakeWorld::Define()
             BeforeEach(
                 [this]()
                 {
-                    AutomationOpenMap("TestEmptyLevel");
+                    AutomationOpenMap("/Game/Tests/TestEmptyLevel");
                     World = GetTestGameWorld();
 
                     constexpr char* GridBPName = "Blueprint'/Game/World/BP_SnakeGrid.BP_SnakeGrid'";
@@ -94,7 +94,7 @@ void FSnakeWorld::Define()
             BeforeEach(
                 [this]()
                 {
-                    AutomationOpenMap("GameLevel");
+                    AutomationOpenMap("/Game/Levels/GameLevel");
                     World = GetTestGameWorld();
                 });
             It("OnlyOneValidModelActorShouldExist",


### PR DESCRIPTION
В настоящий момент карты в тестах фактически не открываются. В этом можно убедится при помощи логов, например: `UE_LOG(LogTemp, Display, TEXT("Current map name: %s"), *UGameplayStatics::GetCurrentLevelName(World))`. Или открыв перед запуском тестов `TestEmptyLevel` (тесты использующие `GameLevel` будут завалены). Данный фикс решает эту проблему. (Проблему выявил на Unreal 5.2.1, на других версиях движка не проверял).