### PR TITLE
lesson 9 - rename SnakeObjectPool -> ObjectPool

### DIFF
--- a/Source/SnakeGame/World/SG_ObjectPool.cpp
+++ b/Source/SnakeGame/World/SG_ObjectPool.cpp
@@ -1,3 +1,3 @@
 // Snake Game, Copyright LifeEXE. All Rights Reserved.
 
-#include "World/SG_SnakeObjectPool.h"
+#include "World/SG_ObjectPool.h"

--- a/Source/SnakeGame/World/SG_ObjectPool.h
+++ b/Source/SnakeGame/World/SG_ObjectPool.h
@@ -4,10 +4,10 @@
 
 #include "CoreMinimal.h"
 #include "UObject/NoExportTypes.h"
-#include "SG_SnakeObjectPool.generated.h"
+#include "SG_ObjectPool.generated.h"
 
 UCLASS()
-class SNAKEGAME_API USG_SnakeObjectPool : public UObject
+class SNAKEGAME_API USG_ObjectPool : public UObject
 {
     GENERATED_BODY()
 
@@ -31,6 +31,7 @@ public:
 
         ActorType* Actor = Pool.IsEmpty() ? World->SpawnActor<ActorType>(ActorClass, Transform) : Cast<ActorType>(Pool.Pop());
         check(Actor);
+        Actor->SetActorTransform(Transform);
         Actor->SetActorHiddenInGame(false);
         return Actor;
     }

--- a/Source/SnakeGame/World/SG_Snake.cpp
+++ b/Source/SnakeGame/World/SG_Snake.cpp
@@ -4,7 +4,7 @@
 #include "World/SG_SnakeLink.h"
 #include "World/SG_WorldUtils.h"
 #include "SnakeGame/Core/Snake.h"
-#include "World/SG_SnakeObjectPool.h"
+#include "World/SG_ObjectPool.h"
 
 namespace
 {
@@ -47,7 +47,7 @@ void ASG_Snake::InitObjectPool()
 {
     if (SnakeObjectPool) return;
 
-    SnakeObjectPool = NewObject<USG_SnakeObjectPool>();
+    SnakeObjectPool = NewObject<USG_ObjectPool>();
     check(SnakeObjectPool);
     SnakeObjectPool->Reserve<ASG_SnakeLink>(GetWorld(), ReservedSnakeLinksNum, SnakeLinkClass);
 }

--- a/Source/SnakeGame/World/SG_Snake.h
+++ b/Source/SnakeGame/World/SG_Snake.h
@@ -14,7 +14,7 @@ class Snake;
 }
 
 class ASG_SnakeLink;
-class USG_SnakeObjectPool;
+class USG_ObjectPool;
 
 UCLASS()
 class SNAKEGAME_API ASG_Snake : public AActor
@@ -52,7 +52,7 @@ private:
     TArray<TObjectPtr<ASG_SnakeLink>> SnakeLinks;
 
     UPROPERTY()
-    TObjectPtr<USG_SnakeObjectPool> SnakeObjectPool{nullptr};
+    TObjectPtr<USG_ObjectPool> SnakeObjectPool{nullptr};
 
     void InitObjectPool();
 };


### PR DESCRIPTION
SetActorTransform should be called in the Pop method because we can can get the actor from the object pool where the last transformation was, whatever that is.